### PR TITLE
Put result into dictionary

### DIFF
--- a/project.k
+++ b/project.k
@@ -12,3 +12,21 @@ returnOrLookup[;`ProcessModel;y]' x}
 
 returnOrLookup:{
 :[x~`creator;h.User.username[((h@y).`creator)[z]];(x~`pvs)&(y~`ProcessModel);h.ProcessModelVariable.name[((h@y).`pvs)[z]];x~`nodes;h.ProcessModelNode.name[((h@y).`nodes)[z]];((h@y)@x)[z]]}
+
+rtdHelper:{.+(x;y)}
+
+/ takes two parameters: a list of aliases from the query, and the values returned
+/ by runQuery
+
+resultToDictionary:{
+rtdHelper[x;]' y}
+
+/ a main function to put things together (at least for now)
+main:{
+a:runQuery[x]
+q:resultToDictionary[(x.columns@\:`alias);a]
+i:.((`startIndex;x.pagingInfo.startIndex;)
+(`batchSize;x.pagingInfo.batchSize;)
+(`total;#q)
+(`result;q))
+i}


### PR DESCRIPTION
Put the result of the query into a dictionary, with paging info included (but not yet actually applied to the result), in order to make the result match the format in the spec.
